### PR TITLE
SW467470: Fix IPMI restricted mode operation

### DIFF
--- a/whitelist-filter.cpp
+++ b/whitelist-filter.cpp
@@ -157,7 +157,7 @@ void WhitelistFilter::postInit()
 
 ipmi::Cc WhitelistFilter::filterMessage(ipmi::message::Request::ptr request)
 {
-    if (request->ctx->channel == ipmi::channelSystemIface && restrictedMode)
+    if (request->ctx->channel == ipmi:channelPrimaryIpmb && restrictedMode)
     {
         if (!std::binary_search(
                 whitelist.cbegin(), whitelist.cend(),


### PR DESCRIPTION
In IPMI restricted mode, only whitelisted commands are allowed. An additional
condition is the channel number, the command is received by the daemon. The
restricted mode only applies for the system interface. The btbridge is yet to
use the new IPMI D-Bus API which will allow assigning the system interface
channel number to btbridge. The following issue will track the switching of
btbridge to new IPMI D-Bus API. Channel number 0 is assigned to btbridge IPMI
commands because of the legacy interface. The restricted mode logic is adjusted
to check for IPMI commands originating from channel 0.

https://github.com/openbmc/btbridge/issues/15

Change-Id: I84f1027e40610ceb3aca6566081fabc70f8aff65
Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>