### PR TITLE
SW468413: Platform event message command support not needed on WS

### DIFF
--- a/sensorhandler.cpp
+++ b/sensorhandler.cpp
@@ -1039,9 +1039,6 @@ void register_netfn_sen_functions()
     ipmi_register_callback(NETFUN_SENSOR, IPMI_CMD_WILDCARD, nullptr,
                            ipmi_sen_wildcard, PRIVILEGE_USER);
 
-    // <Platform Event Message>
-    ipmi_register_callback(NETFUN_SENSOR, IPMI_CMD_PLATFORM_EVENT, nullptr,
-                           ipmicmdPlatformEvent, PRIVILEGE_OPERATOR);
     // <Get Sensor Type>
     ipmi_register_callback(NETFUN_SENSOR, IPMI_CMD_GET_SENSOR_TYPE, nullptr,
                            ipmi_sen_get_sensor_type, PRIVILEGE_USER);


### PR DESCRIPTION
Platform Event message command is not supported on Witherspoon systems. It is typically needed for systems where SEL's are added via the IPMB interface. On master the plan is to add compilation flag so that this command can be turned off for OpenPower systems. The following issue will track handling this change in the master.

https://github.com/openbmc/phosphor-host-ipmid/issues/141

Change-Id: I42138e6043c32c1e7f8704e7864af301f3c6cd67
Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>