### PR TITLE
SW460600: Don't report serviceable action if the watchdog service is …

### DIFF
--- a/app/watchdog.cpp
+++ b/app/watchdog.cpp
@@ -68,13 +68,11 @@ ipmi::RspType<> ipmiAppResetWatchdogTimer()
     {
         const std::string e_str = std::string("wd_reset: ") + e.what();
         log<level::ERR>(e_str.c_str());
-        reportError();
         return ipmi::responseUnspecifiedError();
     }
     catch (...)
     {
         log<level::ERR>("wd_reset: Unknown Error");
-        reportError();
         return ipmi::responseUnspecifiedError();
     }
 }
@@ -239,13 +237,11 @@ ipmi_ret_t ipmi_app_watchdog_set(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
     {
         const std::string e_str = std::string("wd_set: ") + e.what();
         log<level::ERR>(e_str.c_str());
-        reportError();
         return IPMI_CC_UNSPECIFIED_ERROR;
     }
     catch (...)
     {
         log<level::ERR>("wd_set: Unknown Error");
-        reportError();
         return IPMI_CC_UNSPECIFIED_ERROR;
     }
 }
@@ -388,13 +384,11 @@ ipmi_ret_t ipmi_app_watchdog_get(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
     {
         const std::string e_str = std::string("wd_get: ") + e.what();
         log<level::ERR>(e_str.c_str());
-        reportError();
         return IPMI_CC_UNSPECIFIED_ERROR;
     }
     catch (...)
     {
         log<level::ERR>("wd_get: Unknown Error");
-        reportError();
         return IPMI_CC_UNSPECIFIED_ERROR;
     }
 }


### PR DESCRIPTION
…not present

There were a few cases where a service action was reported because the
watchdog service was not present. It was because of a race condition where
the power down operation is trigerred and the watchdog service is shutdown
but if was followed by a watchdog reset. Since the watchdog service is absent
it resulted in an error log which calls for serviceable action. The IPMI error
response code will report the failure to the host platform software.

Change-Id: Iae1026f3f7b56c422ad35bec50db746eda07171d
Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>