### PR TITLE
mapper: remove mapper from host attention path

### DIFF
--- a/host-cmd-manager.cpp
+++ b/host-cmd-manager.cpp
@@ -115,10 +115,9 @@ void Manager::checkQueueAndAlertHost()
     {
         log<level::DEBUG>("Asserting SMS Attention");
 
+        std::string HOST_IPMI_SVC("org.openbmc.HostIpmi");
         std::string IPMI_PATH("/org/openbmc/HostIpmi/1");
         std::string IPMI_INTERFACE("org.openbmc.HostIpmi");
-
-        auto host = ::ipmi::getService(this->bus, IPMI_INTERFACE, IPMI_PATH);
 
         // Start the timer for this transaction
         auto time = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -132,7 +131,7 @@ void Manager::checkQueueAndAlertHost()
         }
 
         auto method =
-            this->bus.new_method_call(host.c_str(), IPMI_PATH.c_str(),
+            this->bus.new_method_call(HOST_IPMI_SVC.c_str(), IPMI_PATH.c_str(),
                                       IPMI_INTERFACE.c_str(), "setAttention");
         auto reply = this->bus.call(method);
 


### PR DESCRIPTION
Error injection testing has shown a significant bottleneck in the host
attention path as the BMC is processing the error and also receiving
commands from an external device requesting writes to the flash.

During this scenario, there are a lot of BMC processes stopping and
starting (as the host is being stopped and error data is collected).
This results in a lot of work for the mapper application. It must delete
its data structure for removed services and introspect all new services.

This heavy workload by mapper not only affects the overall utilization
of the BMC processor, but it also affect any other applications making
D-Bus calls into mapper.

Given the critical nature of this host ipmid code, which is being used
as a part of the protocol with the debug collecting external device,
it's important that mapper not be a bottle neck in this flow. This
commit removes the mapper call from this critical path and just hard
codes the needed service name.

In general, BMC code is moving away from using mapper as a service
lookup application if there is minimal chance of a service being
implemented by multiple applications. In this case, the
org.openbmc.HostIpmi service has had a single implementation since
the beginning of the project.

Tested:
Verified that with this change the error inject was successfully
processed and expected error was logged.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I4db3b309db0169cbb98a9c0fd7527379a9071287