### PR TITLE
[user-mgmt]: Handle out of range error in path

### DIFF
--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -196,12 +196,13 @@ UserAccess& getUserAccessObject()
 
 int getUserNameFromPath(const std::string& path, std::string& userName)
 {
-    static size_t pos = strlen(userObjBasePath) + 1;
-    if (path.find(userObjBasePath) == std::string::npos)
+    constexpr size_t length = strlen(userObjBasePath);
+    if (((length + 1) >= path.size()) ||
+        path.compare(0, length, userObjBasePath))
     {
         return -EINVAL;
     }
-    userName.assign(path, pos, path.size());
+    userName.assign(path, length + 1, path.size());
     return 0;
 }
 


### PR DESCRIPTION
Function must assume that object path without user name may exist,
and must handle the condition accordingly.

Tested:
1. Verified when InterfacesAdded signal sent out from Phosphor-user-manager
under base user object for global attributes, ipmid is not crashed.

Resolves openbmc/phosphor-net-ipmid#10

Change-Id: Ib19af7ca8f05fd9f4553010caf347c677d9897e2
Signed-off-by: Richard Marian Thomaiyar <richard.marian.thomaiyar@linux.intel.com>