### PR TITLE
Add new oemibmserviceagent privilege role

### DIFF
--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -104,7 +104,7 @@ static std::array<std::string, (PRIVILEGE_OEM + 1)> ipmiPrivIndex = {
     "priv-user",     // PRIVILEGE_USER - 2
     "priv-operator", // PRIVILEGE_OPERATOR - 3
     "priv-admin",    // PRIVILEGE_ADMIN - 4
-    "priv-custom"    // PRIVILEGE_OEM - 5
+    "priv-oemibmserviceagent" // PRIVILEGE_OEM - 5
 };
 
 using namespace phosphor::logging;


### PR DESCRIPTION
This enhances phosphor-host-ipmi to accept the new Phosphor privilege role
oemibmserviceagent which corresponds to the OemIBMServiceAgent Redfish role.

Tested:
Minimal testing.  Without this, if any local BMC user has the
priv-oemibmserviceagent role, this service would fail with "Error in
converting to IPMI privilege".
With this fix, the user privilege role is accepted.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>