### PR TITLE
Correct code reading total power from dbus

### DIFF
--- a/dcmihandler.cpp
+++ b/dcmihandler.cpp
@@ -51,7 +51,6 @@ constexpr auto DHCP_OPT12_ENABLED = "SendHostNameEnabled";
 
 constexpr auto SENSOR_VALUE_INTF = "xyz.openbmc_project.Sensor.Value";
 constexpr auto SENSOR_VALUE_PROP = "Value";
-constexpr auto SENSOR_SCALE_PROP = "Scale";
 
 using namespace phosphor::logging;
 
@@ -1012,20 +1011,15 @@ int64_t getPowerReading(sdbusplus::bus::bus& bus)
         auto service = ipmi::getService(bus, SENSOR_VALUE_INTF, objectPath);
 
         // Read the sensor value and scale properties
-        auto properties = ipmi::getAllDbusProperties(bus, service, objectPath,
-                                                     SENSOR_VALUE_INTF);
-        auto value = std::get<int64_t>(properties[SENSOR_VALUE_PROP]);
-        auto scale = std::get<int64_t>(properties[SENSOR_SCALE_PROP]);
-
-        // Power reading needs to be scaled with the Scale value using the
-        // formula Value * 10^Scale.
-        power = value * std::pow(10, scale);
+        auto value = ipmi::getDbusProperty(
+            bus, service, objectPath, SENSOR_VALUE_INTF, SENSOR_VALUE_PROP);
+        power = std::get<double>(value);
     }
     catch (std::exception& e)
     {
-        log<level::INFO>("Failure to read power value from D-Bus object",
-                         entry("OBJECT_PATH=%s", objectPath.c_str()),
-                         entry("INTERFACE=%s", SENSOR_VALUE_INTF));
+        log<level::ERR>("Failure to read power value from D-Bus object",
+                        entry("OBJECT_PATH=%s", objectPath.c_str()),
+                        entry("INTERFACE=%s", SENSOR_VALUE_INTF));
     }
     return power;
 }

--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -99,11 +99,11 @@ static constexpr const char* userGrpProperty = "UserGroups";
 static constexpr const char* userEnabledProperty = "UserEnabled";
 
 static std::array<std::string, (PRIVILEGE_OEM + 1)> ipmiPrivIndex = {
-    "priv-reserved", // PRIVILEGE_RESERVED - 0
-    "priv-callback", // PRIVILEGE_CALLBACK - 1
-    "priv-user",     // PRIVILEGE_USER - 2
-    "priv-operator", // PRIVILEGE_OPERATOR - 3
-    "priv-admin",    // PRIVILEGE_ADMIN - 4
+    "priv-reserved",          // PRIVILEGE_RESERVED - 0
+    "priv-callback",          // PRIVILEGE_CALLBACK - 1
+    "priv-user",              // PRIVILEGE_USER - 2
+    "priv-operator",          // PRIVILEGE_OPERATOR - 3
+    "priv-admin",             // PRIVILEGE_ADMIN - 4
     "priv-oemibmserviceagent" // PRIVILEGE_OEM - 5
 };
 


### PR DESCRIPTION
Original OpenBMC design was to use the Scale property, but that changed
a few years ago. The value no longer needs to be scaled.

Tested on Everest HW

Signed-off-by: Chris Cain <cjcain@us.ibm.com>
Change-Id: I37b73e0c787a66a4a5b7e4bb2ff554b83d6a026f