### PR TITLE
Change Model Number to Part Number for FRU products

### DIFF
--- a/ipmi_fru_info_area.cpp
+++ b/ipmi_fru_info_area.cpp
@@ -382,7 +382,7 @@ FruAreaData buildProductInfoArea(const PropertyMap& propMap)
         appendData(prettyName, propMap, fruAreaData);
 
         // Product part/model number
-        appendData(modelNumber, propMap, fruAreaData);
+        appendData(partNumber, propMap, fruAreaData);
 
         // Product version
         appendData(version, propMap, fruAreaData);


### PR DESCRIPTION
WebUI prints 'Part Number' for FRU Inventory Items. With this commit
we get the 'Part Number' when ipmitool is used to print FRU product
info.

This commit also has a dependency on FRU YAML configuration file.
The PR for FRU YAML configuration file is:
https://github.ibm.com/openbmc/openbmc/pull/1930

This was against our simulation model.
$ ipmitool -I lanplus -C 17 -N 3 -p 2623 -U root -H <host> fru print 1
 Product Name          : Memory DIMM
 Product Part Number   : 78P6575
 Product Serial        : 0001DP911ZZZ

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>