### PR TITLE
set priv-user as the default privilege

### DIFF
--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -506,7 +506,7 @@ bool UserAccess::isValidUserId(const uint8_t userId)
 bool UserAccess::isValidPrivilege(const uint8_t priv)
 {
     // Callback privilege is deprecated in OpenBMC
-    return (isValidPrivLimit(priv) || priv == privNoAccess);
+    return isValidPrivLimit(priv);
 }
 
 uint8_t UserAccess::getUsrMgmtSyncIndex()

--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -1053,7 +1053,8 @@ Cc UserAccess::setUserName(const uint8_t userId, const std::string& userName)
             auto method = bus.new_method_call(
                 getUserServiceName().c_str(), userMgrObjBasePath,
                 userMgrInterface, createUserMethod);
-            method.append(userName.c_str(), availableGroups, "", false);
+            method.append(userName.c_str(), availableGroups,
+                          ipmiPrivIndex[PRIVILEGE_USER], false);
             auto reply = bus.call(method);
         }
         catch (const sdbusplus::exception::SdBusError& e)
@@ -1068,6 +1069,11 @@ Cc UserAccess::setUserName(const uint8_t userId, const std::string& userName)
         std::memcpy(userInfo->userName,
                     static_cast<const void*>(userName.data()), userName.size());
         userInfo->userInSystem = true;
+        for (size_t chIndex = 0; chIndex < ipmiMaxChannels; chIndex++)
+        {
+            userInfo->userPrivAccess[chIndex].privilege =
+                static_cast<uint8_t>(PRIVILEGE_USER);
+        }
     }
     else if (oldUser != userName && validUser)
     {


### PR DESCRIPTION
Currently the users created by ipmitool have NoAccess role/privilege.
The NoAccess role is going away, and the plan is to create user with
ReadOnly privilege. This commit sets newly created user with ReadOnly
privilege by default.

Testing:
1. Attempted to set privilege to NoAccess. Verified the command failed as expected
$ ipmitool -I lanplus -C 17 -N 3 -p 623 -U <user> -P <passwd> -H ever8bmc channel setaccess 1 2 privilege=15
IPMI command failed: Invalid data field in request
Unable to Set User Access (channel 1 id 2)

2. Created a user, and verified the privilege is set to USER
$ ipmitool -I lanplus -C 17 -N 3 -p 623 -U <user> -P <passwd> -H ever8bmc user set name 3 abc3
$ ipmitool -I lanplus -C 17 -N 3 -p 623 -U <user> -P <passwd> -H ever8bmc user list
ID  Name             Callin  Link Auth  IPMI Msg   Channel Priv Limit
1   teeks            false   true       true       ADMINISTRATOR
2   abc2             true    false      false      ADMINISTRATOR
3   abc3             true    false      false      USER
...

3. Verified the Web UI shows the list of created users
