### PR TITLE
Do not add user to ssh group

### DIFF
--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -1049,6 +1049,17 @@ Cc UserAccess::setUserName(const uint8_t userId, const std::string& userName)
             {
                 return ccUnspecifiedError;
             }
+
+            // Remove ssh group, appplies to all user accounts created
+            // irrespective of privilege
+            std::string sshGroup = "ssh";
+            auto it = std::find(std::begin(availableGroups),
+                                std::end(availableGroups), sshGroup);
+            if (it != std::end(availableGroups))
+            {
+                availableGroups.erase(it);
+            }
+
             // Create new user
             auto method = bus.new_method_call(
                 getUserServiceName().c_str(), userMgrObjBasePath,


### PR DESCRIPTION
When an user account is added via ipmitool, the user is added to ipmi,
ssh, and few other groups. Readonly user accounts are not expected to
be included in the ssh group. However, at the time the user account is
created, there is no way to determine the privilege level of the user.
Due to this the user is not going to added to ssh group irrespective
of the user privilege level. To enable Admin user with host console
access, redfish API has to be used to add that user to ssh group.

Testing:
- Create user using ipmitool
Ex:
$ ipmitool -I lanplus -C 17 -N 3 -p 623 -U <user> -H <host> \
user set name 2 <username>

- Verify
uid=1008(username) gid=100(users)
groups=1002(priv-user),1004(ipmi),1005(web),1006(redfish),100(users)

Note that the user is not added to 'hostconsoleaccess' group.

- After setting 'User' privilege to the account, run ssh on port 2200
and check journallog
$ ssh <readonly_user>@ever8bmc -p 2200
Jul 01 18:56:52 ever8bmc dropbear[3017]: Child connection from
9.3.62.26:38524
Jul 01 18:57:14 ever8bmc dropbear[3017]: Logins are restricted to the
group hostconsoleaccess but user 'username' is not a member
Jul 01 18:57:50 ever8bmc dropbear[3017]: Exit before auth from
<9.3.62.26:38524>: (user 'username', 3 fails): Exited normally

- Create user account with Admin privilege via ipmitool, and then add
account to the ssh group via redfish, try ssh, and check log
Jul 01 19:14:33 ever8bmc dropbear[3068]: PAM password auth succeeded for
'ipmiadmin' from 9.3.62.26:38534

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>