### PR TITLE
1060: Fix setting power cap via ipmi throws error

### DIFF
--- a/dcmihandler.cpp
+++ b/dcmihandler.cpp
@@ -399,9 +399,9 @@ ipmi::RspType<uint16_t, // reserved
 }
 
 ipmi::RspType<> setPowerLimit(ipmi::Context::ptr& ctx, uint16_t reserved1,
-                              uint8_t exceptionAction, uint16_t powerLimit,
-                              uint32_t correctionTime, uint16_t reserved2,
-                              uint16_t statsPeriod)
+                              uint8_t reserved2, uint8_t exceptionAction,
+                              uint16_t powerLimit, uint32_t correctionTime,
+                              uint16_t reserved3, uint16_t statsPeriod)
 {
     if (!dcmi::isDCMIPowerMgmtSupported())
     {
@@ -411,7 +411,7 @@ ipmi::RspType<> setPowerLimit(ipmi::Context::ptr& ctx, uint16_t reserved1,
 
     // Only process the power limit requested in watts. Return errors
     // for other fields that are set
-    if (reserved1 || reserved2 || correctionTime || statsPeriod ||
+    if (reserved1 || reserved2 || reserved3 || correctionTime || statsPeriod ||
         exceptionAction != exceptionPowerOff)
     {
         return ipmi::responseInvalidFieldRequest();


### PR DESCRIPTION
Using ipmitool to set the value power cap limit reports the following error:
```
DCMI request failed because: Request data length invalid (c7)
```
It's because when the setPowerLimit method is called, an error occurs because the parameters do not match.

Fixes: https://github.com/ibm-openbmc/dev/issues/3637

Tested:
~# ipmitool dcmi power set_limit limit 10

    Current Limit State: Power Limit Active
    Exception actions:   Hard Power Off & Log Event to SEL
    Power Limit:         10 Watts
    Correction time:     0 milliseconds
    Sampling period:     0 seconds