### PR TITLE
1060: dcmi: fix Get/Set Power Limit issues

### DIFF
--- a/dcmihandler.cpp
+++ b/dcmihandler.cpp
@@ -387,12 +387,12 @@ ipmi::RspType<uint16_t, // reserved
      */
     constexpr uint32_t correctionTime{};
     constexpr uint16_t statsPeriod{};
-    if (!pcapEnable)
+    if (*pcapEnable == false)
     {
         constexpr ipmi::Cc responseNoPowerLimitSet = 0x80;
-        constexpr uint16_t noPcap{};
         return ipmi::response(responseNoPowerLimitSet, reserved1, exception,
-                              noPcap, correctionTime, reserved2, statsPeriod);
+                              *pcapValue, correctionTime, reserved2,
+                              statsPeriod);
     }
     return ipmi::responseSuccess(reserved1, exception, *pcapValue,
                                  correctionTime, reserved2, statsPeriod);


### PR DESCRIPTION
Get Power Limit command:
  Issue: The completion code byte always is 0x00
  Root cause: In the getPowerLimit function, it is checking "pcapEnable"
  is valid or not instead checking the value of "pcapEnable".
  Solution: checking the value of "pcapEnable" is true or false.

Set Power Limit command:
  Issue: The length of command always false.
  Root cause: the first reserved parameter is 3 bytes, not 2 bytes.
  Solution: Add one more reserved byte.

Tested:
  IPMI dcmi set/get power limit commands work well.

Change-Id: I3c97411d9e9c39498c0db64d37e6ca4458161b43