### PR TITLE
1050: dcmi: fix Get/Set Power Limit issues

### DIFF
--- a/dcmihandler.cpp
+++ b/dcmihandler.cpp
@@ -387,21 +387,21 @@ ipmi::RspType<uint16_t, // reserved
      */
     constexpr uint32_t correctionTime{};
     constexpr uint16_t statsPeriod{};
-    if (!pcapEnable)
+    if (*pcapEnable == false)
     {
         constexpr ipmi::Cc responseNoPowerLimitSet = 0x80;
-        constexpr uint16_t noPcap{};
         return ipmi::response(responseNoPowerLimitSet, reserved1, exception,
-                              noPcap, correctionTime, reserved2, statsPeriod);
+                              *pcapValue, correctionTime, reserved2,
+                              statsPeriod);
     }
     return ipmi::responseSuccess(reserved1, exception, *pcapValue,
                                  correctionTime, reserved2, statsPeriod);
 }
 
 ipmi::RspType<> setPowerLimit(ipmi::Context::ptr& ctx, uint16_t reserved1,
-                              uint8_t exceptionAction, uint16_t powerLimit,
-                              uint32_t correctionTime, uint16_t reserved2,
-                              uint16_t statsPeriod)
+                              uint8_t reserved2, uint8_t exceptionAction,
+                              uint16_t powerLimit, uint32_t correctionTime,
+                              uint16_t reserved3, uint16_t statsPeriod)
 {
     if (!dcmi::isDCMIPowerMgmtSupported())
     {
@@ -411,7 +411,7 @@ ipmi::RspType<> setPowerLimit(ipmi::Context::ptr& ctx, uint16_t reserved1,
 
     // Only process the power limit requested in watts. Return errors
     // for other fields that are set
-    if (reserved1 || reserved2 || correctionTime || statsPeriod ||
+    if (reserved1 || reserved2 || reserved3 || correctionTime || statsPeriod ||
         exceptionAction != exceptionPowerOff)
     {
         return ipmi::responseInvalidFieldRequest();


### PR DESCRIPTION
Get Power Limit command:
  Issue: The completion code byte always is 0x00
  Root cause: In the getPowerLimit function, it is checking "pcapEnable"
  is valid or not instead checking the value of "pcapEnable".
  Solution: checking the value of "pcapEnable" is true or false.

Set Power Limit command:
  Issue: The length of command always false.
  Root cause: the first reserved parameter is 3 bytes, not 2 bytes.
  Solution: Add one more reserved byte.

Tested:
  IPMI dcmi set/get power limit commands work well.

Change-Id: I3c97411d9e9c39498c0db64d37e6ca4458161b43