### PR TITLE
1060:CI-only: create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,188 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:50:01Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "app/channel.hpp": [
+      {
+        "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 88,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "include/ipmid/sessionhelper.hpp": [
+      {
+        "hashed_secret": "bbd91e7ee9342675db1c992fe17d8056f4041063",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/session/closesession_unittest.cpp": [
+      {
+        "hashed_secret": "bbd91e7ee9342675db1c992fe17d8056f4041063",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "user_channel/channel_layer.hpp": [
+      {
+        "hashed_secret": "ebf354fa18ded3535d6ffd19110c6e618e331d37",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 111,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "user_channel/passwd_mgr.hpp": [
+      {
+        "hashed_secret": "1f6461178ab7d082e795d44fad639b1927cf457b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 66,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "user_channel/usercommands.cpp": [
+      {
+        "hashed_secret": "fe40ee8d998f2a132bab537081fefa3b0d8cf7f0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 289,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fbc731b382651e9185c5ee5e5c5078195127f3e7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 342,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "user_channel/usercommands.hpp": [
+      {
+        "hashed_secret": "acda92f267ad90500c560923c7818d260e1eb79d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "559a812fdf3b58188748101e9230b65664122a34",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7d0d9e0e989cca2cf5c057d29708ac46d4d2543f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets