### PR TITLE
1050: user_mgmt: Recover corrupted nv files (#17) (#24)

### DIFF
--- a/user_channel/channel_mgmt.cpp
+++ b/user_channel/channel_mgmt.cpp
@@ -1106,6 +1106,15 @@ int ChannelConfig::readChannelPersistData()
         log<level::DEBUG>("Error in opening IPMI Channel data file");
         return -EIO;
     }
+    else if (!std::filesystem::file_size(channelNvDataFilename))
+    {
+        log<level::DEBUG>("NV file (channelNvDataFilename) has a size of zero");
+        if (std::filesystem::remove(channelNvDataFilename))
+        {
+            log<level::DEBUG>("NV file (channelNvDataFilename) is deleted");
+        }
+        return -EIO;
+    }
     try
     {
         // Fill in global structure


### PR DESCRIPTION
#### user_mgmt: Recover corrupted nv files (#17) (#24)
```
For unknown reasons the nv file size become to 0.
To not affect the service, add this condition:
If the file is 0 in size, delete the file and throw the exception.

Related Issue: openbmc/phosphor-host-ipmid#185

Tested:
	Make an empty size file, restart ipmid and confirm the recovery
	was successful.
$ rm /var/lib/ipmi/channel_access_nv.json
$ touch /var/lib/ipmi/channel_access_nv.json
$ systemctl restart phosphor-ipmi-host.service

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>
Co-authored-by: Lulu_Su <63627630+LuluTHSu@users.noreply.github.com>```