### PR TITLE
Adapt to OpenSSH

### DIFF
--- a/chassishandler.cpp
+++ b/chassishandler.cpp
@@ -339,8 +339,7 @@ std::string getAddrStr(uint8_t family, uint8_t* data, uint8_t offset,
     {
         case AF_INET:
         {
-            struct sockaddr_in addr4
-            {};
+            struct sockaddr_in addr4{};
             std::memcpy(&addr4.sin_addr.s_addr, &data[offset], addrSize);
 
             inet_ntop(AF_INET, &addr4.sin_addr, ipAddr, INET_ADDRSTRLEN);
@@ -349,8 +348,7 @@ std::string getAddrStr(uint8_t family, uint8_t* data, uint8_t offset,
         }
         case AF_INET6:
         {
-            struct sockaddr_in6 addr6
-            {};
+            struct sockaddr_in6 addr6{};
             std::memcpy(&addr6.sin6_addr.s6_addr, &data[offset], addrSize);
 
             inet_ntop(AF_INET6, &addr6.sin6_addr, ipAddr, INET6_ADDRSTRLEN);
@@ -1137,7 +1135,7 @@ ipmi::RspType<bool,    // Power is on
               bool,    // last power down caused by a Power overload
               bool,    // last power down caused by a power interlock
               bool,    // last power down caused by power fault
-              bool, // last ‘Power is on’ state was entered via IPMI command
+              bool,    // last ‘Power is on’ state was entered via IPMI command
               uint3_t, // reserved
 
               bool,    // Chassis intrusion active

--- a/dbus-sdr/sensorcommands.cpp
+++ b/dbus-sdr/sensorcommands.cpp
@@ -135,24 +135,24 @@ static sdbusplus::bus::match_t sensorAdded(
     "type='signal',member='InterfacesAdded',arg0path='/xyz/openbmc_project/"
     "sensors/'",
     [](sdbusplus::message_t&) {
-    getSensorTree().clear();
-    getIpmiDecoratorPaths(/*ctx=*/std::nullopt).reset();
-    sdrLastAdd = std::chrono::duration_cast<std::chrono::seconds>(
-                     std::chrono::system_clock::now().time_since_epoch())
-                     .count();
-});
+        getSensorTree().clear();
+        getIpmiDecoratorPaths(/*ctx=*/std::nullopt).reset();
+        sdrLastAdd = std::chrono::duration_cast<std::chrono::seconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+    });
 
 static sdbusplus::bus::match_t sensorRemoved(
     *getSdBus(),
     "type='signal',member='InterfacesRemoved',arg0path='/xyz/openbmc_project/"
     "sensors/'",
     [](sdbusplus::message_t&) {
-    getSensorTree().clear();
-    getIpmiDecoratorPaths(/*ctx=*/std::nullopt).reset();
-    sdrLastRemove = std::chrono::duration_cast<std::chrono::seconds>(
-                        std::chrono::system_clock::now().time_since_epoch())
-                        .count();
-});
+        getSensorTree().clear();
+        getIpmiDecoratorPaths(/*ctx=*/std::nullopt).reset();
+        sdrLastRemove = std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+    });
 
 // this keeps track of deassertions for sensor event status command. A
 // deasertion can only happen if an assertion was seen first.
@@ -165,42 +165,44 @@ static sdbusplus::bus::match_t thresholdChanged(
     "type='signal',member='PropertiesChanged',interface='org.freedesktop.DBus."
     "Properties',arg0namespace='xyz.openbmc_project.Sensor.Threshold'",
     [](sdbusplus::message_t& m) {
-    boost::container::flat_map<std::string, std::variant<bool, double>> values;
-    m.read(std::string(), values);
+        boost::container::flat_map<std::string, std::variant<bool, double>>
+            values;
+        m.read(std::string(), values);
 
-    auto findAssert = std::find_if(values.begin(), values.end(),
-                                   [](const auto& pair) {
-        return pair.first.find("Alarm") != std::string::npos;
-    });
-    if (findAssert != values.end())
-    {
-        auto ptr = std::get_if<bool>(&(findAssert->second));
-        if (ptr == nullptr)
+        auto findAssert = std::find_if(values.begin(), values.end(),
+                                       [](const auto& pair) {
+            return pair.first.find("Alarm") != std::string::npos;
+        });
+        if (findAssert != values.end())
         {
-            phosphor::logging::log<phosphor::logging::level::ERR>(
-                "thresholdChanged: Assert non bool");
-            return;
-        }
-        if (*ptr)
-        {
-            phosphor::logging::log<phosphor::logging::level::INFO>(
-                "thresholdChanged: Assert",
-                phosphor::logging::entry("SENSOR=%s", m.get_path()));
-            thresholdDeassertMap[m.get_path()][findAssert->first] = *ptr;
-        }
-        else
-        {
-            auto& value = thresholdDeassertMap[m.get_path()][findAssert->first];
-            if (value)
+            auto ptr = std::get_if<bool>(&(findAssert->second));
+            if (ptr == nullptr)
+            {
+                phosphor::logging::log<phosphor::logging::level::ERR>(
+                    "thresholdChanged: Assert non bool");
+                return;
+            }
+            if (*ptr)
             {
                 phosphor::logging::log<phosphor::logging::level::INFO>(
-                    "thresholdChanged: deassert",
+                    "thresholdChanged: Assert",
                     phosphor::logging::entry("SENSOR=%s", m.get_path()));
-                value = *ptr;
+                thresholdDeassertMap[m.get_path()][findAssert->first] = *ptr;
+            }
+            else
+            {
+                auto& value =
+                    thresholdDeassertMap[m.get_path()][findAssert->first];
+                if (value)
+                {
+                    phosphor::logging::log<phosphor::logging::level::INFO>(
+                        "thresholdChanged: deassert",
+                        phosphor::logging::entry("SENSOR=%s", m.get_path()));
+                    value = *ptr;
+                }
             }
         }
-    }
-});
+    });
 
 namespace sensor
 {

--- a/include/dbus-sdr/storagecommands.hpp
+++ b/include/dbus-sdr/storagecommands.hpp
@@ -98,8 +98,8 @@ struct Type12Record
                  uint8_t pwrStateNotification, uint8_t capabilities,
                  uint8_t eid, uint8_t entityInst, uint8_t mfrDefined,
                  const std::string& sensorname) :
-        targetAddress(address),
-        channelNumber(chNumber), powerStateNotification(pwrStateNotification),
+        targetAddress(address), channelNumber(chNumber),
+        powerStateNotification(pwrStateNotification),
         deviceCapabilities(capabilities), reserved{}, entityID(eid),
         entityInstance(entityInst), oem(mfrDefined)
     {

--- a/include/ipmid/message.hpp
+++ b/include/ipmid/message.hpp
@@ -47,10 +47,9 @@ struct Context
             uint8_t lun, Cmd cmd, int channel, int userId, uint32_t sessionId,
             Privilege priv, int rqSA, int hostIdx,
             boost::asio::yield_context& yield) :
-        bus(bus),
-        netFn(netFn), lun(lun), cmd(cmd), channel(channel), userId(userId),
-        sessionId(sessionId), priv(priv), rqSA(rqSA), hostIdx(hostIdx),
-        yield(yield)
+        bus(bus), netFn(netFn), lun(lun), cmd(cmd), channel(channel),
+        userId(userId), sessionId(sessionId), priv(priv), rqSA(rqSA),
+        hostIdx(hostIdx), yield(yield)
     {}
 
     std::shared_ptr<sdbusplus::asio::connection> bus;

--- a/include/ipmid/message/pack.hpp
+++ b/include/ipmid/message/pack.hpp
@@ -308,11 +308,9 @@ struct PackSingle<std::variant<T...>>
 {
     static int op(Payload& p, const std::variant<T...>& v)
     {
-        return std::visit(
-            [&p](const auto& arg) {
+        return std::visit([&p](const auto& arg) {
             return PackSingle<std::decay_t<decltype(arg)>>::op(p, arg);
-        },
-            v);
+        }, v);
     }
 };
 

--- a/include/ipmid/types.hpp
+++ b/include/ipmid/types.hpp
@@ -289,7 +289,7 @@ class SecureString : public SecureStringBase
 {
   public:
     using SecureStringBase::basic_string;
-    SecureString(const SecureStringBase& other) : SecureStringBase(other){};
+    SecureString(const SecureStringBase& other) : SecureStringBase(other) {};
     SecureString(SecureString&) = default;
     SecureString(const SecureString&) = default;
     SecureString(SecureString&&) = default;
@@ -308,7 +308,7 @@ class SecureBuffer : public SecureBufferBase
 {
   public:
     using SecureBufferBase::vector;
-    SecureBuffer(const SecureBufferBase& other) : SecureBufferBase(other){};
+    SecureBuffer(const SecureBufferBase& other) : SecureBufferBase(other) {};
     SecureBuffer(SecureBuffer&) = default;
     SecureBuffer(const SecureBuffer&) = default;
     SecureBuffer(SecureBuffer&&) = default;

--- a/transporthandler.hpp
+++ b/transporthandler.hpp
@@ -172,8 +172,7 @@ class ObjectLookupCache
      */
     ObjectLookupCache(sdbusplus::bus_t& bus, const ChannelParams& params,
                       const char* intf) :
-        bus(bus),
-        params(params), intf(intf),
+        bus(bus), params(params), intf(intf),
         objs(getAllDbusObjects(bus, params.logicalPath, intf, ""))
     {}
 

--- a/user_channel/file.hpp
+++ b/user_channel/file.hpp
@@ -42,9 +42,7 @@ class File
      *  @param[in] removeOnExit - File to be removed at exit or no
      */
     File(const std::string& name, const std::string& mode,
-         bool removeOnExit = false) :
-        name(name),
-        removeOnExit(removeOnExit)
+         bool removeOnExit = false) : name(name), removeOnExit(removeOnExit)
     {
         fp = fopen(name.c_str(), mode.c_str());
     }
@@ -57,9 +55,7 @@ class File
      *  @param[in] removeOnExit - File to be removed at exit or no
      */
     File(int fd, const std::string& name, const std::string& mode,
-         bool removeOnExit = false) :
-        name(name),
-        removeOnExit(removeOnExit)
+         bool removeOnExit = false) : name(name), removeOnExit(removeOnExit)
     {
         fp = fdopen(fd, mode.c_str());
     }

--- a/user_channel/user_mgmt.cpp
+++ b/user_channel/user_mgmt.cpp
@@ -716,7 +716,8 @@ bool pamUserCheckAuthenticate(std::string_view username,
 
     pam_handle_t* localAuthHandle = NULL; // this gets set by pam_start
 
-    if (pam_start("dropbear", username.data(), &localConversation,
+    // Authenticate exactly as if we were OpenSSH.
+    if (pam_start("sshd", username.data(), &localConversation,
                   &localAuthHandle) != PAM_SUCCESS)
     {
         log<level::ERR>("User Authentication Failure");


### PR DESCRIPTION
The network IPMI user authentication code tells Linux-PAM it is the `dropbear` service.  The dropbear service was replaced by OpenSSH (`sshd`). This changes the code so IPMI pretends to be the sshd service.

This maintains a hack.  The network IPMI service should define its own PAM config files and use that.  For example add `/etc/pam.d/netipmid` and use `pam_start("netipmid", ...)`.

Tested: No