### PR TITLE
Fix bug in the name of array of whitelisted commands

### DIFF
--- a/generate_whitelist.sh
+++ b/generate_whitelist.sh
@@ -9,7 +9,7 @@ fi
 cat << EOF
 #include <ipmiallowlist.hpp>
 
-const std::vector<netfncmd_pair> whitelist = {
+const std::vector<netfncmd_pair> allowlist = {
 
 EOF
 


### PR DESCRIPTION
The commit 68d9d40530351e3f3db2c00a25969b0efc9fbe3f ("Update terminology used within repo") has changed the name of the array of whitelisted IPMI commands from 'whitelist' to 'allowlist' in the .hpp code, but didn't do it in the "generate_whitelist.sh" script that generates the .cpp file with the relevant array. This leads to the following error message at the service start: """
ipmid[363]: ERROR opening IPMI provider
/usr/lib/ipmid-providers/libwhitelist.so.0.1:
/usr/lib/ipmid-providers/libwhitelist.so.0.1: undefined symbol: allowlist
"""
Correct array name to fix the issue.

Change-Id: I6d2fe94d0712181db13bb71cf2bd71e2db54d6c0